### PR TITLE
group and list unknown SSH banners

### DIFF
--- a/CVE-2024-6387_Check.py
+++ b/CVE-2024-6387_Check.py
@@ -30,8 +30,11 @@ def check_vulnerability(ip, port, timeout, result_queue):
         return
 
     banner = get_ssh_banner(sshsock)
-    if "SSH-2.0-OpenSSH" not in banner:
+    if "SSH-2.0" not in banner:
         result_queue.put((ip, port, 'failed', f"Failed to retrieve SSH banner: {banner}"))
+        return
+    if "SSH-2.0-OpenSSH" not in banner:
+        result_queue.put((ip, port, 'unknown', f"(banner: {banner})"))
         return
 
     vulnerable_versions = [
@@ -117,6 +120,7 @@ def main():
 
     total_scanned = len(ips)
     closed_ports = 0
+    unknown = []
     not_vulnerable = []
     vulnerable = []
 
@@ -124,6 +128,8 @@ def main():
         ip, port, status, message = result_queue.get()
         if status == 'closed':
             closed_ports += 1
+        elif status == 'unknown':
+            unknown.append((ip, message))
         elif status == 'vulnerable':
             vulnerable.append((ip, message))
         elif status == 'not_vulnerable':
@@ -131,6 +137,9 @@ def main():
         else:
             print(f"⚠️ [!] Server at {ip}:{port} is {message}")
 
+    print(f"\n⚠️ Servers with unknown SSH version: {len(unknown)}\n")
+    for ip, msg in unknown:
+        print(f"   [+] Server at {ip} {msg}")
     print(f"\n🛡️ Servers not vulnerable: {len(not_vulnerable)}\n")
     for ip, msg in not_vulnerable:
         print(f"   [+] Server at {ip} {msg}")


### PR DESCRIPTION
An example is `SSH-2.0-ROSSSH` for the Mikrotik RouterOS sshd.