### PR TITLE
make script runnable by fixing print statement

### DIFF
--- a/CVE-2024-6387_Check.py
+++ b/CVE-2024-6387_Check.py
@@ -184,8 +184,7 @@ def main():
 
         while any(future.running() for future in futures):
             with progress_lock:
-                print(f"\rProgress: {
-                      progress_counter}/{total_hosts} hosts scanned", end="")
+                print(f"\rProgress: {progress_counter}/{total_hosts} hosts scanned", end="")
             time.sleep(1)
 
     for future in futures:


### PR DESCRIPTION
I pulled down the repository and it wasn't working, giving the following error:
```
  File "CVE-2024-6387_Check/CVE-2024-6387_Check.py", line 187
    print(f"\rProgress: {
          ^
SyntaxError: unterminated string literal (detected at line 187)
```

This PR fixes that so the script is runnable again.