### PR TITLE
Add exclusion for patched version in Debian unstable

### DIFF
--- a/CVE-2024-6387_Check.py
+++ b/CVE-2024-6387_Check.py
@@ -111,7 +111,8 @@ def check_vulnerability(ip, port, timeout, result_queue):
         'SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.3',
         'SSH-2.0-OpenSSH_9.3p1 Ubuntu-1ubuntu3.6',
         'SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u3',
-        'SSH-2.0-OpenSSH_8.4p1 Debian-5+deb11u3'
+        'SSH-2.0-OpenSSH_8.4p1 Debian-5+deb11u3',
+        'SSH-2.0-OpenSSH_9.7p1 Debian-7'
     ]
 
     if any(version in banner for version in vulnerable_versions) and banner not in excluded_versions:


### PR DESCRIPTION
Fixes false positive for Debian testing/unstable and kali-rolling. See https://security-tracker.debian.org/tracker/CVE-2024-6387