### PR TITLE
grace-time-check option changes and fix

### DIFF
--- a/CVE-2024-6387_Check.py
+++ b/CVE-2024-6387_Check.py
@@ -145,6 +145,7 @@ def check_vulnerability(ip, port, timeout, grace_time_check, use_help_request, r
                     result_queue.put((ip, port, 'vulnerable', f"(running {banner}) Version vulnerable and LoginGraceTime remediation not done (Session was closed by server at {time_elapsed:.1f} seconds)"))
                 else:
                     result_queue.put((ip, port, 'likely_not_vulnerable', f"(running {banner} False negative possible depending on LoginGraceTime)"))
+                sshsock.close()
             else:
                 result_queue.put((ip, port, 'vulnerable', f"(running {banner})"))
         else:

--- a/CVE-2024-6387_Check.py
+++ b/CVE-2024-6387_Check.py
@@ -128,14 +128,23 @@ def check_vulnerability(ip, port, timeout, grace_time_check, use_help_request, r
 
     if any(version in banner for version in vulnerable_versions) and banner not in patched_versions:
         if grace_time_check:
-            time.sleep(grace_time_check)
             sshsock = create_socket(ip, port, timeout)
+            starttime = time.time()
+            banner_throw_away = sshsock.recv(1024).decode(errors='ignore').strip()
+            # Add 4 seconds to whatever grace is given to see if server closes connection before or equal to grace_time_check.
+            sshsock.settimeout(grace_time_check - (time.time() - starttime) + 4)
+            socket_timed_out = 0
+            try:
+                msg = sshsock.recv(1024).decode(errors='ignore').strip()
+            except socket.timeout:
+                # Timeout hit so unless LoginGraceTime is larger than what user specified on command line, the server is likely mitigated by setting LoginGraceTime to 0
+                socket_timed_out = 1
+            time_elapsed = time.time() - starttime
             if sshsock:
-                banner_after_wait = get_ssh_banner(sshsock, use_help_request)
-                if banner == banner_after_wait:
-                    result_queue.put((ip, port, 'vulnerable', f"(running {banner}) with LoginGraceTime mitigation detected (session stayed open for {grace_time_check} seconds)"))
+                if socket_timed_out == 0:
+                    result_queue.put((ip, port, 'vulnerable', f"(running {banner}) Version vulnerable and LoginGraceTime remediation not done (Session was closed by server at {time_elapsed:.1f} seconds)"))
                 else:
-                    result_queue.put((ip, port, 'vulnerable', f"(running {banner})"))
+                    result_queue.put((ip, port, 'likely_not_vulnerable', f"(running {banner} False negative possible depending on LoginGraceTime)"))
             else:
                 result_queue.put((ip, port, 'vulnerable', f"(running {banner})"))
         else:
@@ -236,6 +245,7 @@ def main():
     closed_ports = 0
     unknown = []
     not_vulnerable = []
+    likely_not_vulnerable = []
     vulnerable = []
 
     while not result_queue.empty():
@@ -248,12 +258,18 @@ def main():
             vulnerable.append((ip, port, message))
         elif status == 'not_vulnerable':
             not_vulnerable.append((ip, port, message))
+        elif status == 'likely_not_vulnerable':
+            likely_not_vulnerable.append((ip, port, message))
         else:
             print(f"⚠️ [!] Server at {ip}:{port} is {message}")
 
     print(f"\n🛡️ Servers not vulnerable: {len(not_vulnerable)}")
     for ip, port, msg in not_vulnerable:
         print(f"   [+] Server at {GREEN}{ip}:{port}{ENDC} {msg}")
+    if grace_time_check:
+        print(f"\n🛡️ Servers likely not vulnerable (possible LoginGraceTime remediation): {len(likely_not_vulnerable)}")
+        for ip, port, msg in likely_not_vulnerable:
+            print(f"   [+] Server at {GREEN}{ip}:{port}{ENDC} {msg}")
     print(f"\n🚨 Servers likely vulnerable: {len(vulnerable)}")
     for ip, port, msg in vulnerable:
         print(f"   [+] Server at {RED}{ip}:{port}{ENDC} {msg}")


### PR DESCRIPTION
- Fixed the code for timeout not being detected properly when grace-time-check option is used.
- Added another report section for Server likely not vulnerable when the grace-time-check option is used.  Added text to indicate that it can be a false negative if the sshd_config LoginGraceTime is set higher than the value given by the user for grace-time-check option.
- The grace-time-check code now doesn't check for the banner message.  That is done in the first connection check so not checked again.  The option now just throws away the text sent by the server for the specific grace-time-check code and just waits to see if the server closes the connection before grace-time-check value + 4 seconds.  If it does close the connection then LoginGraceTime is not set to 0 which means the manual config remediation likely isn't done unless the user provided a grace-time-check that is lower than the sshd_config LoginGraceTime setting.