### PR TITLE
Added latest Ubuntu version to patched list

### DIFF
--- a/CVE-2024-6387_Check.py
+++ b/CVE-2024-6387_Check.py
@@ -122,6 +122,7 @@ def check_vulnerability(ip, port, timeout, grace_time_check, use_help_request, d
         'SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.10',
         'SSH-2.0-OpenSSH_9.3p1 Ubuntu-3ubuntu3.6',
         'SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.3',
+        'SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.4',
         'SSH-2.0-OpenSSH_9.3p1 Ubuntu-1ubuntu3.6',
         'SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u3',
         'SSH-2.0-OpenSSH_8.4p1 Debian-5+deb11u3',


### PR DESCRIPTION
Added successor 9.6p1-3ubuntu13.4 (released July 9, 2024) to the list of patched versions.


