### PR TITLE
Added update to include patched OpenSSH version on Ubuntu 24.04.2

### DIFF
--- a/CVE-2024-6387_Check.py
+++ b/CVE-2024-6387_Check.py
@@ -125,6 +125,7 @@ def check_vulnerability(ip, port, timeout, grace_time_check, use_help_request, d
         'SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.3',
         'SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.4',
         'SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5',
+        'SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.11',
         'SSH-2.0-OpenSSH_9.3p1 Ubuntu-1ubuntu3.6',
         'SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u3',
         'SSH-2.0-OpenSSH_8.4p1 Debian-5+deb11u3',


### PR DESCRIPTION
The patched version of OpenSSH for Ubuntu 24.04.2 (as of April 2025) was not included in the list of versions that are not vulnerable.