### PR TITLE
Add patched version for OpenSSH 8.9p1

### DIFF
--- a/CVE-2024-6387_Check.py
+++ b/CVE-2024-6387_Check.py
@@ -122,6 +122,7 @@ def check_vulnerability(ip, port, timeout, grace_time_check, use_help_request, d
     patched_versions = [
         'SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.10',
         'SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.13',
+        'SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.15',
         'SSH-2.0-OpenSSH_9.3p1 Ubuntu-3ubuntu3.6',
         'SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.3',
         'SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.4',


### PR DESCRIPTION
The patched version of OpenSSH for Ubuntu 22.04 (as of April 2026) was not included in the list of versions that are not vulnerable.